### PR TITLE
Popping the stack view not allowed from the main page

### DIFF
--- a/src/ui/GeneralStackView.qml
+++ b/src/ui/GeneralStackView.qml
@@ -45,7 +45,7 @@ Item {
                 anchors.centerIn: parent
 
                 onWalletCreationRequested: {
-                    stackView.push(componentGeneralSwipeView)
+                    stackView.replace(componentGeneralSwipeView)
                 }
             }
         }


### PR DESCRIPTION
Fixes issue #73
Replace the create/load wallet component with the main page instead of pushing the main page