### PR TITLE
Fixes issue #24 - An UI that shows the outputs

### DIFF
--- a/qml.qrc
+++ b/qml.qrc
@@ -21,6 +21,7 @@
         <file>src/ui/Delegates/WalletListAddressDelegate.qml</file>
         <file>src/ui/Delegates/OutputsListDelegate.qml</file>
         <file>src/ui/Delegates/OutputsListAddressDelegate.qml</file>
+        <file>src/ui/Delegates/OutputsListAddressOutputDelegate.qml</file>
         <file>src/ui/Delegates/DestinationListDelegate.qml</file>
         <file>src/ui/Delegates/InputOutputDelegate.qml</file>
         <file>src/ui/Delegates/HistoryListDelegate.qml</file>

--- a/src/ui/Delegates/OutputsListAddressDelegate.qml
+++ b/src/ui/Delegates/OutputsListAddressDelegate.qml
@@ -4,91 +4,67 @@ import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.12
 
 Item {
-    id: root
+    id: outputsListAddressDelegate
 
-    Behavior on height { NumberAnimation { duration: 250; easing.type: Easing.OutQuint } }
+    property bool expanded: false
+    
+    implicitHeight: itemDelegateAddress.height + (expanded ? listViewAddressOutputs.height : 0)
+    Behavior on implicitHeight { NumberAnimation { duration: 250; easing.type: Easing.OutQuint } }
 
-    RowLayout {
-        id: delegateAddressRowLayout
-        anchors.fill: parent
-        anchors.leftMargin: listOutputsLeftMargin
-        anchors.rightMargin: listOutputsRightMargin
-        spacing: listOutputsSpacing
+    clip: true
 
-        Label {
-            id: labelNumber
-            text: index + 1
+    ItemDelegate {
+        id: itemDelegateAddress
+
+        property color textColor: expanded ? parent.Material.accent : parent.Material.foreground
+        Behavior on textColor { ColorAnimation {} }
+
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.leftMargin: 10
+        anchors.right: parent.right
+
+        Material.foreground: textColor
+        icon.source: "qrc:/images/resources/images/icons/qr.svg"
+        icon.width: 16
+        icon.height: 16
+        text: address // a role of the model
+        font.family: "Code New Roman"
+        font.bold: expanded
+
+        onClicked: {
+            expanded = !expanded
         }
+    } // ItemDelegate
+    
+    ListView {
+        id: listViewAddressOutputs
+        anchors.top: itemDelegateAddress.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: contentItem.height
+        
+        opacity: expanded ? 1.0 : 0.0
+        Behavior on opacity { NumberAnimation { duration: expanded ? 250 : 1000; easing.type: Easing.OutQuint } }
 
-        Image {
-            id: qrIcon
-            source: "qrc:/images/resources/images/icons/qr.svg"
-            sourceSize: "16x16"
+        clip: true
+        interactive: false
+        model: modelOutputs
+
+        delegate: OutputsListAddressOutputDelegate {
+            width: listViewAddressOutputs.width
         }
+    } // ListView
 
-        RowLayout {
-            TextInput {
-                id: textAddress
-                text: address // a role of the model
-                readOnly: true
-                font.family: "Code New Roman"
-            }
-            ToolButton {
-                id: toolButtonCopy
-                icon.source: "qrc:/images/resources/images/icons/copy.svg"
-                Layout.alignment: Qt.AlignLeft
-                ToolTip.text: qsTr("Copy to clipboard")
-                ToolTip.visible: hovered // TODO: pressed when mobile?
-                ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
-
-                Image {
-                    id: imageCopied
-                    anchors.centerIn: parent
-                    source: "qrc:/images/resources/images/icons/check-simple.svg"
-                    fillMode: Image.PreserveAspectFit
-                    sourceSize: Qt.size(toolButtonCopy.icon.width*1.5, toolButtonCopy.icon.height*1.5)
-                    z: 1
-
-                    opacity: 0.0
-                }
-
-                onClicked: {
-                    textAddress.selectAll()
-                    textAddress.copy()
-                    textAddress.deselect()
-                    if (copyAnimation.running) {
-                        copyAnimation.restart()
-                    } else {
-                        copyAnimation.start()
-                    }
-                }
-
-                SequentialAnimation {
-                    id: copyAnimation
-                    NumberAnimation { target: imageCopied; property: "opacity"; to: 1.0; easing.type: Easing.OutCubic }
-                    PauseAnimation { duration: 1000 }
-                    NumberAnimation { target: imageCopied; property: "opacity"; to: 0.0; easing.type: Easing.OutCubic }
-                }
-            } // ToolButton
-            Rectangle {
-                id: spacer
-                Layout.fillWidth: true
-            }
-        }
-
-        Label {
-            id: labelAddressSky
-            text: addressSky // a role of the model
-            color: Material.accent
-            horizontalAlignment: Text.AlignRight
-            Layout.preferredWidth: internalLabelsWidth
-        }
-
-        Label {
-            id: labelAddressCoins
-            text: addressCoinHours // a role of the model
-            horizontalAlignment: Text.AlignRight
-            Layout.preferredWidth: internalLabelsWidth
-        }
-    } // RowLayout (addresses)
+    // Roles: outputID, addressSky, addressCoinHours
+    // Use listModel.append( { "outputID": value, "addressSky": value, "addressCoinHours": value } )
+    // Or implement the model in the backend (a more recommendable approach)
+    ListModel {
+        id: modelOutputs
+        // The first element must exist but will not be used
+        ListElement { outputID: "qrxw7364w8xerusftaxkw87ues"; addressSky: 30; addressCoinHours: 1049 }
+        ListElement { outputID: "8745yuetsrk8tcsku4ryj48ije"; addressSky: 12; addressCoinHours: 16011 }
+        ListElement { outputID: "gfdhgs343kweru38200384uwqd"; addressSky: 0; addressCoinHours: 72 }
+        ListElement { outputID: "00qdqsdjkssvmchskjkxxdg374"; addressSky: 521; addressCoinHours: 11 }
+    }
 }

--- a/src/ui/Delegates/OutputsListAddressOutputDelegate.qml
+++ b/src/ui/Delegates/OutputsListAddressOutputDelegate.qml
@@ -1,0 +1,84 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
+import QtQuick.Layouts 1.12
+
+Item {
+    id: outputsListAddressOutputDelegate
+
+    implicitHeight: Math.max(textOutputID.height, (toolButtonCopy.height - toolButtonCopy.topPadding*2), labelAddressSky.height, labelAddressCoins.height)
+
+    RowLayout {
+        id: rowLayoutRoot
+        anchors.fill: parent
+        anchors.leftMargin: listOutputsLeftMargin * 2
+        anchors.rightMargin: listOutputsRightMargin
+        spacing: listOutputsSpacing
+
+        RowLayout {
+            id: rowLayoutOutputID
+            Layout.fillWidth: true
+
+            TextInput {
+                id: textOutputID
+                Layout.fillWidth: true
+                text: outputID // a role of the model
+                readOnly: true
+                font.family: "Code New Roman"
+                wrapMode: TextInput.WrapAnywhere
+            }
+            ToolButton {
+                id: toolButtonCopy
+                icon.source: "qrc:/images/resources/images/icons/copy.svg"
+                Layout.alignment: Qt.AlignLeft
+                ToolTip.text: qsTr("Copy to clipboard")
+                ToolTip.visible: hovered // TODO: pressed when mobile?
+                ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+
+                Image {
+                    id: imageCopied
+                    anchors.centerIn: parent
+                    source: "qrc:/images/resources/images/icons/check-simple.svg"
+                    fillMode: Image.PreserveAspectFit
+                    sourceSize: Qt.size(toolButtonCopy.icon.width*1.5, toolButtonCopy.icon.height*1.5)
+                    z: 1
+
+                    opacity: 0.0
+                }
+
+                onClicked: {
+                    textOutputID.selectAll()
+                    textOutputID.copy()
+                    textOutputID.deselect()
+                    if (copyAnimation.running) {
+                        copyAnimation.restart()
+                    } else {
+                        copyAnimation.start()
+                    }
+                }
+
+                SequentialAnimation {
+                    id: copyAnimation
+                    NumberAnimation { target: imageCopied; property: "opacity"; to: 1.0; easing.type: Easing.OutCubic }
+                    PauseAnimation { duration: 1000 }
+                    NumberAnimation { target: imageCopied; property: "opacity"; to: 0.0; easing.type: Easing.OutCubic }
+                }
+            } // ToolButton
+        } // RowLayout (output ID)
+
+        Label {
+            id: labelAddressSky
+            text: addressSky // a role of the model
+            color: Material.accent
+            horizontalAlignment: Text.AlignRight
+            Layout.preferredWidth: internalLabelsWidth/2
+        }
+
+        Label {
+            id: labelAddressCoins
+            text: addressCoinHours // a role of the model
+            horizontalAlignment: Text.AlignRight
+            Layout.preferredWidth: internalLabelsWidth
+        }
+    } // RowLayout (addresses)
+}

--- a/src/ui/Delegates/OutputsListDelegate.qml
+++ b/src/ui/Delegates/OutputsListDelegate.qml
@@ -6,75 +6,62 @@ import QtQuick.Layouts 1.12
 Item {
     id: outputsListDelegate
 
-    readonly property real delegateHeight: 30
     property bool expanded: false
-    // The following property is used to avoid a binding conflict with the `height` property.
-    // Also avoids a bug with the animation when collapsing a wallet
-    readonly property real finalViewHeight: expanded ? delegateHeight*(addressList.count) + 50 : 0
+    property bool animateDisplacement: false
 
-    width: listOutputs.width
-    height: itemDelegateMainButton.height + (expanded ? finalViewHeight : 0)
+    implicitHeight: itemDelegateWalletName.height + (expanded ? listViewAddresses.height : 0)
+    Behavior on implicitHeight { NumberAnimation { duration: animateDisplacement ? 250 : 0; easing.type: Easing.OutQuint; onRunningChanged: animateDisplacement = false } }
 
-    Behavior on height { NumberAnimation { duration: 250; easing.type: Easing.OutQuint } }
+    clip: true
 
-    ColumnLayout {
-        id: delegateColumnLayout
-        anchors.fill: parent
+    ItemDelegate {
+        id: itemDelegateWalletName
 
-        ItemDelegate {
-            id: itemDelegateMainButton
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignTop
-            font.bold: expanded
+        property color textColor: expanded ? parent.Material.accent : parent.Material.foreground
+        Behavior on textColor { ColorAnimation {} }
 
-            RowLayout {
-                id: delegateRowLayout
-                anchors.fill: parent
-                anchors.leftMargin: listOutputsLeftMargin
-                anchors.rightMargin: listOutputsRightMargin
-                spacing: listOutputsSpacing
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
 
-                Label {
-                    id: labelWalletName
-                    text: name // a role of the model
-                    Layout.fillWidth: true
-                }
-            }
+        Material.foreground: textColor
+        text: name // a role of the model
+        font.bold: true
 
-            onClicked: {
-                expanded = !expanded
-            }
-        } // ItemDelegate
-
-        ListView {
-            id: addressList
-            model: listAddresses
-            implicitHeight: expanded ? delegateHeight*(addressList.count) + 50 : 0
-            opacity: expanded ? 1.0 : 0.0
-            clip: true
-            interactive: false
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignTop
-
-            Behavior on implicitHeight { NumberAnimation { duration: 250; easing.type: Easing.OutQuint } }
-            Behavior on opacity { NumberAnimation { duration: expanded ? 250 : 1000; easing.type: Easing.OutQuint } }
-
-            delegate: OutputsListAddressDelegate {
-                width: listOutputs.width
-                height: visible ? delegateHeight : 0
-            }
+        onClicked: {
+            animateDisplacement = true
+            expanded = !expanded
         }
-    } // ColumnLayout
+    } // ItemDelegate
 
-    // Roles: address, addressSky, addressCoinHours
-    // Use listModel.append( { "address": value, "addressSky": value, "addressCoinHours": value } )
+    ListView {
+        id: listViewAddresses
+        anchors.top: itemDelegateWalletName.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: contentItem.height
+
+        opacity: expanded ? 1.0 : 0.0
+        Behavior on opacity { NumberAnimation { duration: expanded ? 250 : 1000; easing.type: Easing.OutQuint } }
+        
+        clip: true
+        interactive: false
+        model: modelAddresses
+
+        delegate: OutputsListAddressDelegate {
+            width: listViewAddresses.width
+        }
+    } // ListView
+
+    // Roles: address
+    // Use listModel.append( { "address": value } )
     // Or implement the model in the backend (a more recommendable approach)
     ListModel {
-        id: listAddresses
+        id: modelAddresses
         // The first element must exist but will not be used
-        ListElement { address: "qrxw7364w8xerusftaxkw87ues"; addressSky: 30; addressCoinHours: 1049 }
-        ListElement { address: "8745yuetsrk8tcsku4ryj48ije"; addressSky: 12; addressCoinHours: 16011 }
-        ListElement { address: "gfdhgs343kweru38200384uwqd"; addressSky: 0; addressCoinHours: 72 }
-        ListElement { address: "00qdqsdjkssvmchskjkxxdg374"; addressSky: 521; addressCoinHours: 11 }
+        ListElement { address: "qrxw7364w8xerusftaxkw87ues" }
+        ListElement { address: "8745yuetsrk8tcsku4ryj48ije" }
+        ListElement { address: "gfdhgs343kweru38200384uwqd" }
+        ListElement { address: "00qdqsdjkssvmchskjkxxdg374" }
     }
 }

--- a/src/ui/Outputs.qml
+++ b/src/ui/Outputs.qml
@@ -13,7 +13,7 @@ Page {
     readonly property real listOutputsLeftMargin: 20
     readonly property real listOutputsRightMargin: 50
     readonly property real listOutputsSpacing: 20
-    readonly property real internalLabelsWidth: 70
+    readonly property real internalLabelsWidth: 60
 
     Frame {
         id: frame
@@ -31,23 +31,18 @@ Page {
                 RowLayout {
                     spacing: listOutputsSpacing
                     Layout.topMargin: 30
-
+                    
                     Label {
-                        text: qsTr("No.")
+                        text: qsTr("Output ID")
                         font.pointSize: 9
-                        Layout.leftMargin: listOutputsLeftMargin
-                        Layout.preferredWidth: 45 // Obtained empirically
-                    }
-                    Label {
-                        text: qsTr("Addresses")
-                        font.pointSize: 9
+                        Layout.leftMargin: 38
                         Layout.fillWidth: true
                     }
                     Label {
                         text: qsTr("Sky")
                         font.pointSize: 9
                         horizontalAlignment: Text.AlignRight
-                        Layout.preferredWidth: internalLabelsWidth
+                        Layout.preferredWidth: internalLabelsWidth/2
                     }
                     Label {
                         text: qsTr("Coin hours")
@@ -70,22 +65,25 @@ Page {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+                
                 ListView {
-                    id: listOutputs
+                    id: listViewWallets
                     anchors.fill: parent
                     clip: true
 
-                    model: modelOutputs
-                    delegate: OutputsListDelegate { }
+                    model: modelWallets
+                    delegate: OutputsListDelegate {
+                        width: listViewWallets.width
+                    }
                 } // ListView
             } // ScrollView
-        }
+        } // ColumnLayout (frame)
     } // Frame
 
     // Roles: name
     // Implement the model in the backend (a more recommendable approach)
     ListModel { // EXAMPLE
-        id: modelOutputs
+        id: modelWallets
         ListElement { name: "Wallet A" }
         ListElement { name: "Wallet B" }
         ListElement { name: "Wallet C" }


### PR DESCRIPTION
In `Outputs.qml` and related files:
- Implement a `OutputsListAddressOutputDelegate` QML component to represent a single output of some address and implement a test model to it
- Replace layouts with anchors and reimplement all transitions and animations
- Now the `Outputs` page have 3 lists, one embedded into another (Wallets -> Addresses -> Outputs)