### PR TITLE
Fixes issue #97 - Turn QR code images into buttons

### DIFF
--- a/src/ui/Delegates/DestinationListDelegate.qml
+++ b/src/ui/Delegates/DestinationListDelegate.qml
@@ -3,8 +3,14 @@ import QtQuick.Controls 2.12
 import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.12
 
+// Resource imports
+import "../" // For quick UI development, switch back to resources when making a release
+
 Item {
     id: root
+
+    signal qrCodeRequested(var data)
+
     clip: true
 
     RowLayout {
@@ -21,9 +27,15 @@ Item {
         RowLayout {
             Layout.fillWidth: true
             spacing: 8
-            Image {
-                source: "qrc:/images/resources/images/icons/qr.svg"
-                sourceSize: "24x24"
+
+            ToolButtonQR {
+                id: toolButtonQR
+
+                iconSize: "24x24"
+
+                onClicked: {
+                    qrCodeRequested(address)
+                }
             }
             TextField {
                 id: textFieldDestinationAddress

--- a/src/ui/Delegates/HistoryListDelegate.qml
+++ b/src/ui/Delegates/HistoryListDelegate.qml
@@ -19,6 +19,8 @@ ItemDelegate {
     property int modelHoursBurned: hoursBurned
     property string modelTransactionID
 
+    signal qrCodeRequested(var data)
+
     implicitWidth: parent.width
     implicitHeight: (columnLayoutMainContent.height < 78 ? 78 : columnLayoutMainContent.height) + rowLayoutRoot.anchors.topMargin + rowLayoutRoot.anchors.bottomMargin
 
@@ -65,10 +67,17 @@ ItemDelegate {
                 RowLayout {
                     id: rowLayoutSent
                     visible: modelType === TransactionDetails.Type.Send
-                    Image {
-                        source: "qrc:/images/resources/images/icons/qr.svg"
-                        sourceSize: "24x24"
+
+                    ToolButtonQR {
+                        id: toolButtonQRSent
+
+                        iconSize: "24x24"
+
+                        onClicked: {
+                            qrCodeRequested(sentAddress)
+                        }
                     }
+
                     Label {
                         text: sentAddress // model's role
                         font.family: "Code New Roman"
@@ -77,10 +86,17 @@ ItemDelegate {
                 }
                 RowLayout {
                     id: rowLayoutReceive
-                    Image {
-                        source: "qrc:/images/resources/images/icons/qr.svg"
-                        sourceSize: "24x24"
+
+                    ToolButtonQR {
+                        id: toolButtonQRReceived
+
+                        iconSize: "24x24"
+
+                        onClicked: {
+                            qrCodeRequested(receivedAddress)
+                        }
                     }
+                    
                     Label {
                         text: receivedAddress // model's role
                         font.family: "Code New Roman"

--- a/src/ui/Delegates/OutputsListAddressDelegate.qml
+++ b/src/ui/Delegates/OutputsListAddressDelegate.qml
@@ -3,10 +3,15 @@ import QtQuick.Controls 2.12
 import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.12
 
+// Resource imports
+import "../" // For quick UI development, switch back to resources when making a release
+
 Item {
     id: outputsListAddressDelegate
 
     property bool expanded: false
+
+    signal qrCodeRequested(var data)
     
     implicitHeight: itemDelegateAddress.height + (expanded ? listViewAddressOutputs.height : 0)
     Behavior on implicitHeight { NumberAnimation { duration: 250; easing.type: Easing.OutQuint } }
@@ -23,14 +28,23 @@ Item {
         anchors.left: parent.left
         anchors.leftMargin: 10
         anchors.right: parent.right
+        leftPadding: padding + toolButtonQR.width
 
         Material.foreground: textColor
-        icon.source: "qrc:/images/resources/images/icons/qr.svg"
-        icon.width: 16
-        icon.height: 16
         text: address // a role of the model
         font.family: "Code New Roman"
         font.bold: expanded
+
+        ToolButtonQR {
+            id: toolButtonQR
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.leftMargin: 10
+
+            onClicked: {
+                qrCodeRequested(address)
+            }
+        }
 
         onClicked: {
             expanded = !expanded

--- a/src/ui/Delegates/WalletListAddressDelegate.qml
+++ b/src/ui/Delegates/WalletListAddressDelegate.qml
@@ -3,6 +3,9 @@ import QtQuick.Controls 2.12
 import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.12
 
+// Resource imports
+import "../" // For quick UI development, switch back to resources when making a release
+
 Item {
     id: root
 
@@ -11,6 +14,7 @@ Item {
 
     signal addAddressesRequested()
     signal editWalletRequested()
+    signal qrCodeRequested(var data)
 
     visible: itemVisible || opacity > 0.0
     opacity: itemVisible ? 1.0 : 0.0
@@ -92,11 +96,12 @@ Item {
             text: index
         }
 
-        Image {
-            id: qrIcon
-            visible:  !showOnlyAddresses
-            source: "qrc:/images/resources/images/icons/qr.svg"
-            sourceSize: "16x16"
+        ToolButtonQR {
+            id: toolButtonQR
+
+            onClicked: {
+                qrCodeRequested(address)
+            }
         }
 
         RowLayout {

--- a/src/ui/Dialogs/DialogQR.qml
+++ b/src/ui/Dialogs/DialogQR.qml
@@ -1,0 +1,20 @@
+import QtQuick 2.12
+import QtQuick.Layouts 1.12
+import QtQuick.Controls 2.12
+
+Dialog {
+    id: dialogQR
+
+    property alias imagePath: imageQR.source
+
+    title: Qt.application.name + " - QR"
+    standardButtons: Dialog.Close
+
+    Image {
+        id: imageQR
+        anchors.fill: parent
+
+        fillMode: Image.PreserveAspectFit
+        verticalAlignment: Qt.AlignTop
+    }
+}

--- a/src/ui/SubPageSendSimple.qml
+++ b/src/ui/SubPageSendSimple.qml
@@ -5,6 +5,8 @@ import QtQuick.Layouts 1.12
 Page {
     id: root
 
+    signal qrCodeRequested(var data)
+
     ColumnLayout {
         id: columnLayoutRoot
         anchors.fill: parent
@@ -35,11 +37,18 @@ Page {
             RowLayout {
                 Layout.fillWidth: true
                 spacing: 8
-                Image {
-                    source: "qrc:/images/resources/images/icons/qr.svg"
-                    sourceSize: "24x24"
+
+                ToolButtonQR {
+                    id: toolButtonQR
                     Layout.bottomMargin: 4
+
+                    iconSize: "24x24"
+
+                    onClicked: {
+                        qrCodeRequested(textFieldWalletsSendTo.text)
+                    }
                 }
+                
                 TextField {
                     id: textFieldWalletsSendTo
                     font.family: "Code New Roman"

--- a/src/ui/ToolButtonQR.qml
+++ b/src/ui/ToolButtonQR.qml
@@ -1,0 +1,16 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+
+ToolButton {
+    id: toolButtonQR
+
+    property size iconSize: "16x16"
+
+    icon.source: "qrc:/images/resources/images/icons/qr.svg"
+    icon.width: iconSize.width
+    icon.height: iconSize.height
+
+    ToolTip.text: qsTr("Show QR code")
+    ToolTip.visible: hovered // TODO: pressed when mobile?
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+}

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -101,6 +101,18 @@ ApplicationWindow {
                  + "sunt in culpa qui officia deserunt mollit anim id est laborum.")
     }
 
+    // QR
+    DialogQR {
+        id: dialogQR
+        anchors.centerIn: Overlay.overlay
+        width: applicationWindow.width > 540 ? 540 - 40 : applicationWindow.width - 40
+        height: applicationWindow.height > 570 ? 570 - 40 : applicationWindow.height - 40
+
+        focus: true
+        modal: true
+        imagePath: "qrc:/images/resources/images/icons/qr.svg"
+    }
+
     // Hardware dialogs
 
     DialogUnconfiguredWallet {


### PR DESCRIPTION
- Implement a `ToolButtonQR` QML component
- Replace QR images with a `ToolButtonQR` component and also add a `qrCodeRequested()` signal, which is emited when the QR button mentioned above is clicked