### PR TITLE
Reduce number of operations in wallet manager

### DIFF
--- a/src/models/walletsManager.go
+++ b/src/models/walletsManager.go
@@ -24,7 +24,8 @@ type WalletManager struct {
 	wallets             []*QWallet
 	addresseseByWallets map[string][]*QAddress
 	outputsByAddress    map[string][]*QOutput
-	_                   func()                                                                                                                                 `slot:"updateWalletEnv"`
+	altManager          core.AltcoinManager
+	_                   func()                                                                                                                                 `slot:"updateWalletEnvs"`
 	_                   func(wltId, address string)                                                                                                            `slot:"updateOutputs"`
 	_                   func(string)                                                                                                                           `slot:"updateAddresses"`
 	_                   func()                                                                                                                                 `slot:"updateWallets"`
@@ -79,6 +80,7 @@ func (walletM *WalletManager) init() {
 
 		walletM.SeedGenerator = new(sky.SeedService)
 		walletManager = walletM
+		walletM.updateWalletEnvs()
 	})
 
 	walletM = walletManager
@@ -99,10 +101,10 @@ func GetWalletManager() *WalletManager {
 }
 func (walletM *WalletManager) updateWalletEnvs() {
 	walletsEnvs := make([]core.WalletEnv, 0)
+
 	for _, plug := range walletM.altManager.ListRegisteredPlugins() {
 		walletsEnvs = append(walletsEnvs, plug.LoadWalletEnvs()...)
 	}
-
 	walletM.WalletEnv = walletsEnvs[0]
 }
 


### PR DESCRIPTION
Fixes #172 

Changes:
- Add updateWallets, updateAddresses and updateOutputs methods to WalletManager
- Whit the previous mentioned methods the functions of get the wallets, addresses, and outputs are separated from the function of load it
- A wallets, addresses and outputs properties are added to WalletManager to cach the values

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no
related to PR skycoin/hardware-wallet-protob# for issue skycoin/hardware-wallet-protob#

Requires testing
no

Comments about testing , should you have some
