### PR TITLE
Fix #278 Unable to sign transactions

### DIFF
--- a/src/coin/skycoin/models/wallet.go
+++ b/src/coin/skycoin/models/wallet.go
@@ -1288,7 +1288,6 @@ func (wlt *LocalWallet) signSkycoinTxn(txn core.Transaction, pwd core.PasswordRe
 	if len(skyTxn.Sigs) == 0 {
 		skyTxn.Sigs = make([]cipher.Sig, len(skyTxn.In))
 	}
-
 	signedTxn, err := wallet.SignTransaction(skyWlt, skyTxn, index, uxouts)
 
 	if err != nil {
@@ -1297,15 +1296,21 @@ func (wlt *LocalWallet) signSkycoinTxn(txn core.Transaction, pwd core.PasswordRe
 	}
 	if isReadableTxn {
 		vins := make([]visor.TransactionInput, 0)
-		for _, ux := range uxouts {
-			vin, err := visor.NewTransactionInput(ux, 0)
+		for i, ux := range uxouts {
+			calCh, err := util.GetCoinValue(originalInputs[i].CalculatedHours, CoinHour)
+			if err != nil {
+				return nil, err
+			}
+			vin := visor.TransactionInput{
+				UxOut:           ux,
+				CalculatedHours: calCh,
+			}
 			if err != nil {
 				logWallet.WithError(err).Warn("Couldn't create a transaction input")
 				return nil, err
 			}
 			vins = append(vins, vin)
 		}
-
 		crtTxn, err := api.NewCreatedTransaction(signedTxn, vins)
 		if err != nil {
 			return nil, err

--- a/src/coin/skycoin/models/wallet.go
+++ b/src/coin/skycoin/models/wallet.go
@@ -1307,9 +1307,10 @@ func (wlt *LocalWallet) signSkycoinTxn(txn core.Transaction, pwd core.PasswordRe
 		}
 
 		crtTxn, err := api.NewCreatedTransaction(signedTxn, vins)
-
+		if err != nil {
+			return nil, err
+		}
 		crtTxn.In = originalInputs
-		fmt.Println(4)
 		if err != nil {
 			logWallet.WithError(err).Warn("Couldn't create an un SkycoinCreatedTransaction")
 			return nil, err
@@ -1321,7 +1322,6 @@ func (wlt *LocalWallet) signSkycoinTxn(txn core.Transaction, pwd core.PasswordRe
 			return nil, err
 		}
 	}
-	fmt.Println(5)
 	return resultTxn, nil
 
 }

--- a/src/coin/skycoin/models/wallet.go
+++ b/src/coin/skycoin/models/wallet.go
@@ -1135,7 +1135,6 @@ func (wlt *LocalWallet) signSkycoinTxn(txn core.Transaction, pwd core.PasswordRe
 	walletDir := filepath.Join(wlt.WalletDir, wlt.Id)
 	skyWlt, err := wallet.Load(walletDir)
 	var originalInputs []api.CreatedTransactionInput
-
 	if err != nil {
 		logWallet.WithError(err).Warn("Couldn't load api client")
 		return nil, err
@@ -1143,7 +1142,6 @@ func (wlt *LocalWallet) signSkycoinTxn(txn core.Transaction, pwd core.PasswordRe
 	rTxn, isReadableTxn := txn.(skytypes.ReadableTxn)
 	if isReadableTxn {
 		// Readable tranasctions should not need extra API calls
-
 		cTxn, err := rTxn.ToCreatedTransaction()
 		if err != nil {
 			logWallet.WithError(err).Warn("Failed to convert to readable transaction")
@@ -1220,7 +1218,6 @@ func (wlt *LocalWallet) signSkycoinTxn(txn core.Transaction, pwd core.PasswordRe
 		}
 	} else {
 		// Raw transaction
-
 		unTxn, ok := txn.(*SkycoinUninjectedTransaction)
 		if !ok {
 			logWallet.WithError(err).Warn("Couldn't load transaction un injected")
@@ -1298,7 +1295,6 @@ func (wlt *LocalWallet) signSkycoinTxn(txn core.Transaction, pwd core.PasswordRe
 		logWallet.WithError(err).Warn("Couldn't sign transaction using local wallet")
 		return nil, err
 	}
-
 	if isReadableTxn {
 		vins := make([]visor.TransactionInput, 0)
 		for _, ux := range uxouts {
@@ -1311,13 +1307,13 @@ func (wlt *LocalWallet) signSkycoinTxn(txn core.Transaction, pwd core.PasswordRe
 		}
 
 		crtTxn, err := api.NewCreatedTransaction(signedTxn, vins)
-		crtTxn.In = originalInputs
 
+		crtTxn.In = originalInputs
+		fmt.Println(4)
 		if err != nil {
 			logWallet.WithError(err).Warn("Couldn't create an un SkycoinCreatedTransaction")
 			return nil, err
 		}
-
 		resultTxn = NewSkycoinCreatedTransaction(*crtTxn)
 	} else {
 		resultTxn, err = NewUninjectedTransaction(signedTxn, txnFee)
@@ -1325,7 +1321,7 @@ func (wlt *LocalWallet) signSkycoinTxn(txn core.Transaction, pwd core.PasswordRe
 			return nil, err
 		}
 	}
-
+	fmt.Println(5)
 	return resultTxn, nil
 
 }

--- a/src/coin/skycoin/models/wallet_test.go
+++ b/src/coin/skycoin/models/wallet_test.go
@@ -1237,8 +1237,12 @@ func TestLocalWalletSignSkycoinTxn(t *testing.T) {
 	skyTxn := NewSkycoinCreatedTransaction(*crtTxn)
 	sig, err := util.LookupSignServiceForWallet(wlt, core.UID(""))
 	require.Nil(t, err)
-	_, err = wlt.Sign(skyTxn, sig, pwd, nil)
+	signed, err := wlt.Sign(skyTxn, sig, pwd, nil)
 	require.Nil(t, err)
+
+	ok, err := signed.IsFullySigned()
+	require.Nil(t, err)
+	require.True(t, ok)
 
 	//Test that calculated hours were calculated ok
 	txn.Out[0].Hours = 1000
@@ -1249,8 +1253,12 @@ func TestLocalWalletSignSkycoinTxn(t *testing.T) {
 	skyTxn = NewSkycoinCreatedTransaction(*crtTxn)
 	sig, err = util.LookupSignServiceForWallet(wlt, core.UID(""))
 	require.Nil(t, err)
-	_, err = wlt.Sign(skyTxn, sig, pwd, nil)
+	signed, err = wlt.Sign(skyTxn, sig, pwd, nil)
 	require.Nil(t, err)
+
+	ok, err = signed.IsFullySigned()
+	require.Nil(t, err)
+	require.True(t, ok)
 
 }
 

--- a/src/coin/skycoin/models/wallet_test.go
+++ b/src/coin/skycoin/models/wallet_test.go
@@ -1240,7 +1240,7 @@ func TestLocalWalletSignSkycoinTxn(t *testing.T) {
 	_, err = wlt.Sign(skyTxn, sig, pwd, nil)
 	require.Nil(t, err)
 
-	//More coinHours in outputs that in inputs
+	//Test that calculated hours were calculated ok
 	txn.Out[0].Hours = 1000
 	txn.UpdateHeader()
 	crtTxn, err = api.NewCreatedTransaction(&txn, vins)

--- a/src/coin/skycoin/models/wallet_test.go
+++ b/src/coin/skycoin/models/wallet_test.go
@@ -1215,7 +1215,8 @@ func TestLocalWalletSignSkycoinTxn(t *testing.T) {
 	CleanGlobalMock()
 
 	//Test skycoinCreatedTransaction
-	txn, keyData, uxs, _ := makeTransactionMultipleInputs(t, 1)
+	txn, keyData, uxs, err := makeTransactionMultipleInputs(t, 1)
+	require.Nil(t, err)
 	require.Equal(t, txn.In[0], uxs[0].Hash())
 	vins := make([]visor.TransactionInput, 0)
 	for _, un := range uxs {
@@ -1246,7 +1247,8 @@ func TestLocalWalletSignSkycoinTxn(t *testing.T) {
 
 	//Test that calculated hours were calculated ok
 	txn.Out[0].Hours = 1000
-	txn.UpdateHeader()
+	err = txn.UpdateHeader()
+	require.Nil(t, err)
 	crtTxn, err = api.NewCreatedTransaction(&txn, vins)
 	require.Nil(t, err)
 	require.NotNil(t, crtTxn)

--- a/src/coin/skycoin/models/wallet_test.go
+++ b/src/coin/skycoin/models/wallet_test.go
@@ -1214,6 +1214,7 @@ func TestLocalWalletSpend(t *testing.T) {
 func TestLocalWalletSignSkycoinTxn(t *testing.T) {
 	CleanGlobalMock()
 
+	//Test skycoinCreatedTransaction
 	txn, keyData, uxs, _ := makeTransactionMultipleInputs(t, 1)
 	require.Equal(t, txn.In[0], uxs[0].Hash())
 	vins := make([]visor.TransactionInput, 0)
@@ -1222,8 +1223,6 @@ func TestLocalWalletSignSkycoinTxn(t *testing.T) {
 		require.Nil(t, err)
 		vins = append(vins, vin)
 	}
-	txn.Out[0].Hours = 1000
-	txn.UpdateHeader()
 	txn.Sigs = []cipher.Sig{}
 	crtTxn, err := api.NewCreatedTransaction(&txn, vins)
 	require.Nil(t, err)
@@ -1240,6 +1239,19 @@ func TestLocalWalletSignSkycoinTxn(t *testing.T) {
 	require.Nil(t, err)
 	_, err = wlt.Sign(skyTxn, sig, pwd, nil)
 	require.Nil(t, err)
+
+	//More coinHours in outputs that in inputs
+	// txn.Out[0].Hours = 1000
+	// txn.UpdateHeader()
+	// crtTxn, err = api.NewCreatedTransaction(&txn, vins)
+	// require.Nil(t, err)
+	// require.NotNil(t, crtTxn)
+
+	// skyTxn = NewSkycoinCreatedTransaction(*crtTxn)
+	// sig, err = util.LookupSignServiceForWallet(wlt, core.UID(""))
+	// require.Nil(t, err)
+	// _, err = wlt.Sign(skyTxn, sig, pwd, nil)
+	// require.EqualError(t, err, "morefe")
 }
 
 func TestSkycoinWalletTypes(t *testing.T) {

--- a/src/coin/skycoin/models/wallet_test.go
+++ b/src/coin/skycoin/models/wallet_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SkycoinProject/skycoin/src/visor"
 
@@ -1210,6 +1211,37 @@ func TestLocalWalletSpend(t *testing.T) {
 	require.Equal(t, crtTxn.Transaction.TxID, ret.GetId())
 }
 
+func TestLocalWalletSignSkycoinTxn(t *testing.T) {
+	CleanGlobalMock()
+
+	txn, keyData, uxs, _ := makeTransactionMultipleInputs(t, 1)
+	require.Equal(t, txn.In[0], uxs[0].Hash())
+	vins := make([]visor.TransactionInput, 0)
+	for _, un := range uxs {
+		vin, err := visor.NewTransactionInput(un, uint64(time.Now().Unix()))
+		require.Nil(t, err)
+		vins = append(vins, vin)
+	}
+	txn.Out[0].Hours = 1000
+	txn.UpdateHeader()
+	txn.Sigs = []cipher.Sig{}
+	crtTxn, err := api.NewCreatedTransaction(&txn, vins)
+	require.Nil(t, err)
+	require.NotNil(t, crtTxn)
+
+	wlts := makeLocalWalletsFromKeyData(t, keyData)
+	wlt := wlts[0]
+	pwd := func(string, core.KeyValueStore) (string, error) {
+		return "", nil
+	}
+
+	skyTxn := NewSkycoinCreatedTransaction(*crtTxn)
+	sig, err := util.LookupSignServiceForWallet(wlt, core.UID(""))
+	require.Nil(t, err)
+	_, err = wlt.Sign(skyTxn, sig, pwd, nil)
+	require.Nil(t, err)
+}
+
 func TestSkycoinWalletTypes(t *testing.T) {
 	var wltSet core.WalletSet = &SkycoinRemoteWallet{}
 	require.Equal(t, wallet.WalletTypeBip44, wltSet.DefaultWalletType())
@@ -1509,13 +1541,11 @@ func TestSkycoinSignServiceSign(t *testing.T) {
 	require.NotNil(t, apiCreTxn)
 	require.Equal(t, apiCreTxn.InnerHash, txn.HashInner().Hex())
 	skyCreTxn := NewSkycoinCreatedTransaction(*apiCreTxn)
-
 	signedTxn, err := signer.Sign(skyCreTxn, isds, pwdReader)
 	require.NoError(t, err)
 	require.NotNil(t, signedTxn)
 	err = signedTxn.VerifySigned()
 	require.NoError(t, err)
-	// require.Equal(t, txn.Hash().String(), signedTxn.GetId())
 
 	// SkycoinUninjectedTransaction
 	txn.Sigs = []cipher.Sig{}

--- a/src/coin/skycoin/models/wallet_test.go
+++ b/src/coin/skycoin/models/wallet_test.go
@@ -1241,17 +1241,17 @@ func TestLocalWalletSignSkycoinTxn(t *testing.T) {
 	require.Nil(t, err)
 
 	//More coinHours in outputs that in inputs
-	// txn.Out[0].Hours = 1000
-	// txn.UpdateHeader()
-	// crtTxn, err = api.NewCreatedTransaction(&txn, vins)
-	// require.Nil(t, err)
-	// require.NotNil(t, crtTxn)
+	txn.Out[0].Hours = 1000
+	txn.UpdateHeader()
+	crtTxn, err = api.NewCreatedTransaction(&txn, vins)
+	require.Nil(t, err)
+	require.NotNil(t, crtTxn)
+	skyTxn = NewSkycoinCreatedTransaction(*crtTxn)
+	sig, err = util.LookupSignServiceForWallet(wlt, core.UID(""))
+	require.Nil(t, err)
+	_, err = wlt.Sign(skyTxn, sig, pwd, nil)
+	require.Nil(t, err)
 
-	// skyTxn = NewSkycoinCreatedTransaction(*crtTxn)
-	// sig, err = util.LookupSignServiceForWallet(wlt, core.UID(""))
-	// require.Nil(t, err)
-	// _, err = wlt.Sign(skyTxn, sig, pwd, nil)
-	// require.EqualError(t, err, "morefe")
 }
 
 func TestSkycoinWalletTypes(t *testing.T) {


### PR DESCRIPTION
Fixes #278 
**Changes:**
- Add test for LocalWallet::signSkycoinTxn method
- Change how to set the calculated coin hours to createdTransactions in LocalWallet::signSkycoinTxn method

**Does this change need to mentioned in CHANGELOG.md?**
no

**Requires testing**
Requires testing
yes
