### PR TITLE
Fixes #337 - FormatCoins problem with representations of numbers less than zero

### DIFF
--- a/src/models/walletsManager.go
+++ b/src/models/walletsManager.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/fibercrypto/fibercryptowallet/src/coin/skycoin/params"
@@ -874,8 +873,7 @@ func fromWalletToQWallet(wlt core.Wallet, isEncrypted bool) *QWallet {
 		return qWallet
 	}
 
-	floatBl := float64(bl) / float64(accuracy)
-	qWallet.SetSky(fmt.Sprint(floatBl))
+	qWallet.SetSky(util.FormatCoins(bl, accuracy))
 
 	bl, err = wlt.GetCryptoAccount().GetBalance(sky.CoinHoursTicker)
 	if err != nil {
@@ -883,7 +881,13 @@ func fromWalletToQWallet(wlt core.Wallet, isEncrypted bool) *QWallet {
 		logWalletManager.WithError(err).Error("Couldn't get Coin Hours balance")
 		return qWallet
 	}
-	qWallet.SetCoinHours(fmt.Sprint(bl))
+	accuracy, err = util.AltcoinQuotient(params.CoinHoursTicker)
+	if err != nil {
+		qWallet.SetCoinHours("N/A")
+		logWalletManager.WithError(err).Error("Couldn't get Coin Hours Altcoin quotient")
+		return qWallet
+	}
+	qWallet.SetCoinHours(util.FormatCoins(bl, accuracy))
 
 	return qWallet
 }

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -55,7 +55,7 @@ func FormatCoins(n uint64, quotient uint64) string {
 	lenQ := len(strconv.FormatUint(quotient, 10)) - 1
 	nFormatted := FormatUint64(n / quotient)
 	if lenQ > len(number) {
-		return nFormatted
+		return strconv.FormatFloat(float64(n)/float64(quotient), 'f', -1, 64)
 	}
 	reminder := number[len(number)-lenQ:]
 	reminder = RemoveZeros(reminder)

--- a/src/util/util_test.go
+++ b/src/util/util_test.go
@@ -61,7 +61,8 @@ func TestFormatCoins(t *testing.T) {
 		{name: "format4", value: uint64(12340), result: "1.234", quotient: uint64(10000)},
 		{name: "format5", value: uint64(421142), result: "4,211.42", quotient: uint64(100)},
 		{name: "format6", value: uint64(0), result: "0", quotient: uint64(100)},
-		{name: "format7", value: uint64(42), result: "0", quotient: uint64(10000)},
+		{name: "format7", value: uint64(42), result: "0.0042", quotient: uint64(10000)},
+		{name: "format8", value: uint64(1000), quotient: uint64(1000000), result: ("0.001")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #337 

**Changes:**
- Set `Sky` and `CoinHours` properties of qWallet properly using FormatCoins in model for Wallet page.
- Add a test case for FormatCoins
- Divide number by its accuracy when its less that the accuracy

**Does this change need to mentioned in CHANGELOG.md?**
no

**Requires testing**
no
