### PR TITLE
Set the size of the splash dialog from the implicit size

### DIFF
--- a/src/ui/splash.qml
+++ b/src/ui/splash.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.12
 import QtQuick.Controls.Material 2.12
 import QtQuick.Window 2.12
 import QtQuick.Layouts 1.12
+import Qt.labs.settings 1.0
 
 Window {
     id: windowSplash
@@ -14,6 +15,8 @@ Window {
     color: "transparent"
     x: (Screen.width - width)/2
     y: (Screen.height - height)/2
+
+    Material.theme: ~~settings.value("style/material/theme", Material.Light)
 
     Dialog {
         id: dialogSplash
@@ -34,6 +37,8 @@ Window {
         height: implicitHeight + (implicitHeight % 2)
 
         ColumnLayout {
+            anchors.fill: parent
+            
             Image {
                 id: imageLogo
                 Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
@@ -91,5 +96,9 @@ Window {
         interval: 200
         repeat: false
         onTriggered: dialogSplash.close()
+    }
+
+    Settings {
+        id: settings
     }
 }

--- a/src/ui/splash.qml
+++ b/src/ui/splash.qml
@@ -30,10 +30,8 @@ Window {
         onRejected: Qt.exit(-1)
         onClosed: windowSplash.visible = false
 
-        width: 300
-        height: 300
-        // The width/height must be always greater than its implicit version:
-        // onAboutToShow: console.log("Size:", width + 'x' + height, "Implicit size:", implicitWidth + 'x' + implicitHeight)
+        width: implicitWidth + (implicitWidth % 2)
+        height: implicitHeight + (implicitHeight % 2)
 
         ColumnLayout {
             Image {


### PR DESCRIPTION
**Changes:**
- Set the size of the splash dialog from the implicit size, ensuring the size is always an even number, to avoid sub-pixel alignment.
- Add support for the **Dark Material Theme**